### PR TITLE
[INT-1610] Custom credentials keys

### DIFF
--- a/oauth-function-template/oauth-config.js
+++ b/oauth-function-template/oauth-config.js
@@ -78,7 +78,7 @@ const SCHEMA = {
       default: undefined
     }
   },
-  credentialsKey: {
+  credentialKeys: {
     clientId: {
       doc: "Client ID key to match from ENV variables",
       format: String,
@@ -95,8 +95,8 @@ const SCHEMA = {
 module.exports.createConfig = (configuration) => {
   const config = convict(SCHEMA);
   config.load(configuration);
-  let clientIdKey = _.get(config, 'credentialsKey.clientId', 'CLIENT_ID');
-  let clientSecretKey = _.get(config, 'credentialsKey.clientSecret', 'CLIENT_SECRET');
+  let clientIdKey = _.get(config, 'credentialKeys.clientId', 'CLIENT_ID');
+  let clientSecretKey = _.get(config, 'credentialKeys.clientSecret', 'CLIENT_SECRET');
   if (!(process.env.get(clientIdKey))) {
     throw new Error(`${clientIdKey} environment variable not set`);
   }

--- a/oauth-function-template/oauth-config.js
+++ b/oauth-function-template/oauth-config.js
@@ -96,10 +96,10 @@ module.exports.createConfig = (configuration) => {
   const config = convict(SCHEMA);
   config.load(configuration);
   let clientIdKey = _.get(config, 'credentialKeys.clientId', 'CLIENT_ID');
-  let clientSecretKey = _.get(config, 'credentialKeys.clientSecret', 'CLIENT_SECRET');
   if (!(process.env.get(clientIdKey))) {
     throw new Error(`${clientIdKey} environment variable not set`);
   }
+  let clientSecretKey = _.get(config, 'credentialKeys.clientSecret', 'CLIENT_SECRET');
   if (!(process.env.get(clientSecretKey))) {
     throw new Error(`${clientSecretKey} environment variable not set`);
   }

--- a/oauth-function-template/oauth-config.js
+++ b/oauth-function-template/oauth-config.js
@@ -1,5 +1,6 @@
 const convict = require('convict');
 const stringFormat = require('string-format');
+const _ = require('lodash');
 
 // Define a schema
 const SCHEMA = {
@@ -77,21 +78,34 @@ const SCHEMA = {
       default: undefined
     }
   },
+  credentialsKey: {
+    clientId: {
+      doc: "Client ID key to match from ENV variables",
+      format: String,
+      default: undefined
+    },
+    clientSecret: {
+      doc: "Client Secret key to match from ENV variables",
+      format: String,
+      default: undefined
+    },
+  }
 };
 
 module.exports.createConfig = (configuration) => {
   const config = convict(SCHEMA);
   config.load(configuration);
-
-  if (!(process.env.CLIENT_ID)) {
-    throw new Error('CLIENT_ID environment variable not set');
+  let clientIdKey = _.get(config, 'credentialsKey.clientId', 'CLIENT_ID');
+  let clientSecretKey = _.get(config, 'credentialsKey.clientSecret', 'CLIENT_SECRET');
+  if (!(process.env.get(clientIdKey))) {
+    throw new Error(`${clientIdKey} environment variable not set`);
   }
-  if (!(process.env.CLIENT_SECRET)) {
-    throw new Error('CLIENT_SECRET environment variable not set');
+  if (!(process.env.get(clientSecretKey))) {
+    throw new Error(`${clientSecretKey} environment variable not set`);
   }
 
-  config.set('credentials.client.id', process.env.CLIENT_ID);
-  config.set('credentials.client.secret', process.env.CLIENT_SECRET);
+  config.set('credentials.client.id', process.env.get(clientIdKey));
+  config.set('credentials.client.secret', process.env.get(clientSecretKey));
 
   if (config.get('callbackUrl')) {
     // This formats the callback url dynamically based on the deployed function

--- a/oauth-function-template/package.json
+++ b/oauth-function-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dronedeploy/oauth-function-template",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Function template providing configurable OAuth 2.0 support for Dronedeploy Functions",
   "homepage": "https://github.com/dronedeploy/oauth-function-template",
   "repository": {
@@ -12,6 +12,7 @@
   "dependencies": {
     "@dronedeploy/function-wrapper": "1.1.6",
     "convict": "4.2.0",
+    "lodash": "^4.17.15",
     "node-fetch": "^2.6.0",
     "simple-oauth2": "1.5.2",
     "string-format": "2.0.0"

--- a/oauth-function-template/template/README.md
+++ b/oauth-function-template/template/README.md
@@ -29,6 +29,6 @@ empty then for each `/refresh` request this url is called. Field `accessToken` s
 `Forbidden` status, then appropriate `OAuth Table` is cleaned up in the same way as the user
  logging out.
  
-The `credentialsKey` parameter is optional parameter, which is used to store custom credentials keys,
+The `credentialKeys` parameter is optional parameter, which is used to store custom credentials keys,
 which are set into oauth2 `client.id` and `client.secret`. If missing default values (`CLIENT_ID`, `CLIENT_SECRET`) 
 are applied. If keys are defined for specific settings, the Environment variables with given keys, should be provided.

--- a/oauth-function-template/template/README.md
+++ b/oauth-function-template/template/README.md
@@ -28,3 +28,7 @@ empty then for each `/refresh` request this url is called. Field `accessToken` s
 `OAuth Table` is used as authorization token, if given. If url response give back `Unauthorized` or 
 `Forbidden` status, then appropriate `OAuth Table` is cleaned up in the same way as the user
  logging out.
+ 
+The `credentialsKey` parameter is optional parameter, which is used to store custom credentials keys,
+which are set into oauth2 `client.id` and `client.secret`. If missing default values (`CLIENT_ID`, `CLIENT_SECRET`) 
+are applied. If keys are defined for specific settings, the Environment variables with given keys, should be provided.


### PR DESCRIPTION
**Ticket**
https://dronedeploy.atlassian.net/browse/INT-1610

**Work done**
New field 'credentialsKey' is added to oauth template. If clientId and clienSecret are defined for given settings, then proper values from .env file are used for oauth. Version is bumped 14.1->1.5.0