### PR TITLE
[INT-1636] Change version spec for @dronedeploy/function-wrapper dependency

### DIFF
--- a/oauth-function-template/package.json
+++ b/oauth-function-template/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "main": "index.js",
   "dependencies": {
-    "@dronedeploy/function-wrapper": "1.1.6",
+    "@dronedeploy/function-wrapper": "^1.2.3",
     "convict": "4.2.0",
     "node-fetch": "^2.6.0",
     "simple-oauth2": "1.5.2",


### PR DESCRIPTION
This change will allow to upgrade @dronedeploy/function-wrapper dependency to new compatibile versions in packages that use oauth-function-template.