### PR TITLE
[INT-1932] Bump length limit of accessToken and refreshToken

### DIFF
--- a/oauth-function-template/datastore/queries.js
+++ b/oauth-function-template/datastore/queries.js
@@ -57,7 +57,7 @@ let ACCESS_TOKEN_COLUMN = {
   input: {
     columnType: "TEXT",
     name: "accessToken",
-    textLength: 1024,
+    textLength: 4096,
     textEncrypted: true,
     description: "Holds the current access token"
   }
@@ -75,7 +75,7 @@ let REFRESH_TOKEN_COLUMN = {
   input: {
     columnType: "TEXT",
     name: "refreshToken",
-    textLength: 512,
+    textLength: 4096,
     textEncrypted: true,
     description: "Holds the current refresh token"
   }

--- a/oauth-function-template/package.json
+++ b/oauth-function-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dronedeploy/oauth-function-template",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Function template providing configurable OAuth 2.0 support for Dronedeploy Functions",
   "homepage": "https://github.com/dronedeploy/oauth-function-template",
   "repository": {


### PR DESCRIPTION
### Work done
Bumped maximum length for accessToken from 1k to 4k and for refreshToken from 512b to 4k. There's no size limit for JWT tokens and 4k should give us enough space for sane tokens (unfortunately we can't define variable length text fields in the Datastore).

This will affect only newly deployed apps, which "OAuth Table" was not already created.
