### PR TITLE
[INT-1932] Revert function-wrapper version bump

### DIFF
--- a/oauth-function-template/package.json
+++ b/oauth-function-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dronedeploy/oauth-function-template",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Function template providing configurable OAuth 2.0 support for Dronedeploy Functions",
   "homepage": "https://github.com/dronedeploy/oauth-function-template",
   "repository": {
@@ -10,7 +10,7 @@
   "license": "MIT",
   "main": "index.js",
   "dependencies": {
-    "@dronedeploy/function-wrapper": "^1.2.3",
+    "@dronedeploy/function-wrapper": "1.1.6",
     "convict": "4.2.0",
     "lodash": "^4.17.15",
     "node-fetch": "^2.6.0",


### PR DESCRIPTION
New version of function-wrapper breaks `oauth-function-templates`. This PR revert that version bump.
Version change for function-wrapper was introduced only in recent release of oauth-function-templates (1.5.1).