### PR TITLE
[INT-2183] Added logging to client credentials refresh

### DIFF
--- a/oauth-function-template/handlers/clientCredentials.js
+++ b/oauth-function-template/handlers/clientCredentials.js
@@ -30,9 +30,15 @@ class ClientCredentialsHandler {
           .then((row) => {
             const needRefresh = !row.ok || this.doesTokenNeedRefresh(row.data);
             if (needRefresh) {
+              console.log('Client credentials token needs to be refreshed - refreshing.');
               return this.refreshClientCredentials(this.tokenConfig)
-                .then((tokenObj) => this.storeClientCredentialsToken(table, tokenObj));
+                .then((tokenObj) => this.storeClientCredentialsToken(table, tokenObj))
+                .then((result) => {
+                  console.log('Client credentials token refreshed.');
+                  return result;
+                });
             }
+            console.log('Client credentials are fresh - no need to refresh.');
             return Promise.resolve();
           })
           .then(() => res.status(200).send());


### PR DESCRIPTION
- Added logging to client credentials refresh
    - wanted to add to all graphql requests, but those are done directly only in oauth table creation, for which there are logs which are enough for our needs right now, so no graphql related logging added